### PR TITLE
Fix Script Entrypoint

### DIFF
--- a/proteuscmd/__main__.py
+++ b/proteuscmd/__main__.py
@@ -151,5 +151,9 @@ def ip_delete(proteus, ip):
     proteus.delete_ip4_address(ip, range_id)
 
 
-if __name__ == '__main__':
+def main():
     cli()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(filename):
 
 setup(
     name='proteuscmd',
-    version='0.5',
+    version='0.6',
     description=description_text,
     url='https://github.com/virtUOS/proteuscmd',
     author='Lars Kiesow',


### PR DESCRIPTION
The entrypoint configuration is assuming a `main()` method which didn't exist any longer. This patch reintroduces the method.