### PR TITLE
Fail on error in HTTP GET requests

### DIFF
--- a/proteuscmd/api.py
+++ b/proteuscmd/api.py
@@ -43,6 +43,8 @@ class Proteus:
                                 params=params,
                                 headers=self.__auth_header,
                                 timeout=30)
+        if response.status_code >= 300:
+            raise Exception(f'Error from requesting {path}: {response.text}')
         return response.json()
 
     def __delete(self, path, params):


### PR DESCRIPTION
If an HTTP GET requests returns an error code, we should fail with an exception instead of just continueing and potentially run into other problems.