### PR TITLE
Allow configuring defaults for admin info

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This can be useful if, for example, all your domains also have an alternate doma
 }
 ```
 
-Furthermore, you can configure maps between IPv4 and IPv6 networks:
+You can configure maps between IPv4 and IPv6 networks:
 ```json
 {
     ...
@@ -42,6 +42,16 @@ Furthermore, you can configure maps between IPv4 and IPv6 networks:
             "prefix": "2001:123:456:789::/64"
         }
     ]
+```
+
+Finally, you can configure default values for admin information.
+You can still overwrite them on the command line if needed.
+```json
+{
+    ...
+    "admin_email": "someone@example.com",
+    "admin_name": "John Doe",
+    "admin_phone": "1234"
 ```
 
 

--- a/proteuscmd/__main__.py
+++ b/proteuscmd/__main__.py
@@ -5,7 +5,7 @@ import json
 from functools import wraps
 from proteuscmd.api import Proteus
 from proteuscmd.config import proteus_from_config, config
-from proteuscmd.types import IP_TYPE, IP_STATE_TYPE, VIEW_TYPE
+from proteuscmd.types import IP_TYPE, IP_STATE_TYPE, VIEW_TYPE, ConfigOption
 
 
 __view_args = {
@@ -128,11 +128,11 @@ def ip_get(proteus: Proteus, version, ip):
 @ip.command(name='set')
 @click.option('--name', required=False,
               help='Name of the host. Defaults to hostname if set.')
-@click.option('--admin-email', '-e', required=True,
+@click.option('--admin-email', '-e', cls=ConfigOption, required=True,
               help='Email address of the host admin')
-@click.option('--admin-name', '-n', required=True,
+@click.option('--admin-name', '-n', cls=ConfigOption, required=True,
               help='Name of the host admin')
-@click.option('--admin-phone', '-p', required=True,
+@click.option('--admin-phone', '-p', cls=ConfigOption, required=True,
               help='Phone number of the host admin')
 @click.option('--comment', '-c',
               help='Comment to add to the address registration')

--- a/proteuscmd/types.py
+++ b/proteuscmd/types.py
@@ -2,6 +2,20 @@ import click
 import ipaddress
 import socket
 
+from proteuscmd.config import config
+
+
+class ConfigOption(click.Option):
+    def handle_parse_result(self, ctx, opts, args):
+        # If the option is not provided in the command line,
+        # try to get it from the global config
+        if self.name and self.name not in opts and config(self.name):
+            opts = dict(opts)
+            opts[self.name] = config(self.name)
+
+        # Call the parent class's handle_parse_result to continue
+        return super(ConfigOption, self).handle_parse_result(ctx, opts, args)
+
 
 class IPType(click.ParamType):
     '''Click parameter type for IPv4 or IPv6 address.


### PR DESCRIPTION
This patch allows users to configure default values for information about the administrator. Defaults can still be overwritten via the command line, but if configured, the command line options are no longer required.